### PR TITLE
Auto height computation 

### DIFF
--- a/scripts/jquery.msgBox.js
+++ b/scripts/jquery.msgBox.js
@@ -175,6 +175,7 @@ function msg (options) {
         divMsgBoxButtons = $("#"+divMsgBoxButtonsId);
         divMsgBoxBackGround = $("#"+divMsgBoxBackGroundId);
     }
+    divMsgBoxContent.height('auto');
 
     var width = divMsgBox.width();
     var height = divMsgBox.height();


### PR DESCRIPTION
When the height of the content text is too much, it overflows the message box. To avoid this overflow problem, height of the divMsgBoxContent set to be computed automatically. 
